### PR TITLE
Make encrypt.sh more cool. fix shellcheck issues.

### DIFF
--- a/encrypt.sh
+++ b/encrypt.sh
@@ -37,8 +37,6 @@ elif (( ${#files[@]} == 0 )); then
     files=(.)
 fi
 
-printf '%s\n' "${files[@]}"
-
 if [[ -z "$output" ]]; then
     output="${files[-1]}"
     files=("${files[@]:0:${#files[@]}-1}")


### PR DESCRIPTION
Added argument handling akin to most gnu file utils. multiple files and paths can be given and if no -o or --output is specified, it defaults to using the last file as the "destination."

Also you shouldn't use compression-then-encrypt due to potential compression oracle attacks that are known to exist. A relevant crypto link is in the source file.